### PR TITLE
Kotlin and Java complexity analysis support

### DIFF
--- a/lib/analysers/java/index.js
+++ b/lib/analysers/java/index.js
@@ -1,0 +1,17 @@
+/*
+ * code-forensics
+ * Copyright (C) 2016-2021 Silvio Montanari
+ * Distributed under the GNU General Public License v3.0
+ * see http://www.gnu.org/licenses/gpl.html
+ */
+
+var JavaAnalyser = require('./java_analyser'),
+    utils        = require('../../utils');
+
+var factory = new utils.SingletonFactory(JavaAnalyser);
+
+module.exports = {
+  analyser: function() {
+    return factory.instance();
+  }
+};

--- a/lib/analysers/java/java_analyser.js
+++ b/lib/analysers/java/java_analyser.js
@@ -1,0 +1,284 @@
+/*
+ * code-forensics
+ * Copyright (C) 2016-2021 Silvio Montanari
+ * Distributed under the GNU General Public License v3.0
+ * see http://www.gnu.org/licenses/gpl.html
+ */
+
+var _ = require('lodash'),
+  Parser = require('tree-sitter'),
+  Java = require('tree-sitter-java'),
+  StringDecoder = require('string_decoder').StringDecoder,
+  logger = require('../../log'),
+  utils = require('../../utils');
+
+var decoder = new StringDecoder();
+
+module.exports = function () {
+
+  var DECISION_POINT_NODE_TYPES = [
+    // branching
+    'if_statement',
+    'ternary_expression',
+    // loops
+    'for_statement',
+    'enhanced_for_statement',
+    'while_statement',
+    'do_statement',
+    // exceptions
+    'catch_clause'
+  ];
+
+  var CALLABLE_NODE_TYPES = [
+    'method_declaration',
+    'constructor_declaration',
+    'compact_constructor_declaration',
+    'lambda_expression',
+    'static_initializer',
+    'instance_initializer'
+  ];
+
+  function isCallableNode(node) {
+    return CALLABLE_NODE_TYPES.indexOf(node.type) !== -1;
+  }
+
+  function hasLogicalOperator(node) {
+    for (var i = 0; i < node.childCount; i++) {
+      var child = node.child(i);
+      if (child && (child.type === '&&' || child.type === '||')) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+
+  function parseTreeFromContent(content) {
+    // Create a fresh parser per parse to avoid concurrency issues.
+    var parser = new Parser();
+    parser.setLanguage(Java);
+    // tree-sitter JS bindings expect a string (or a function). Ensure a string.
+    var input;
+    if (typeof content === 'string') {
+      input = content;
+    } else if (Buffer.isBuffer(content)) {
+      input = content.toString('utf8');
+    } else {
+      input = decoder.write(content);
+    }
+
+    // tree-sitter JS binding can fail with "Invalid argument" for larger strings.
+    // Use function input for large sources to avoid size limits.
+    var chunkSize = 4096;
+    return parser.parse(function(index) {
+      if (index >= input.length) return null;
+      return input.slice(index, index + chunkSize);
+    });
+  }
+
+  function cyclomaticComplexity(content) {
+    var tree;
+    try {
+      tree = parseTreeFromContent(content);
+    } catch (e) {
+      logger.error('Java CC parse error: ' + e.message);
+      throw e;
+    }
+    var complexity = 1;
+
+    function visit(node) {
+      try {
+        if (DECISION_POINT_NODE_TYPES.indexOf(node.type) !== -1) {
+          complexity++;
+        } else if (node.type === 'switch_label') {
+          // Each switch label (case/default) contributes a decision point.
+          complexity++;
+        } else if (node.type === 'binary_expression') {
+          if (hasLogicalOperator(node)) {
+            complexity++;
+          }
+        }
+
+        for (var i = 0; i < node.namedChildCount; i++) {
+          visit(node.namedChild(i));
+        }
+      } catch (e) {
+        throw e;
+      }
+    }
+
+    visit(tree.rootNode);
+    return complexity;
+  }
+
+  function safeLine(node) {
+    try {
+      return (node.startPosition && typeof node.startPosition.row === 'number')
+        ? (node.startPosition.row + 1)
+        : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function nodeHasText(node) {
+    return node && typeof node.text === 'string' && node.text.length > 0;
+  }
+
+  function findFirstNamedDescendant(node, predicate) {
+    if (!node) return null;
+    if (predicate(node)) return node;
+    for (var i = 0; i < node.namedChildCount; i++) {
+      var found = findFirstNamedDescendant(node.namedChild(i), predicate);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  function findBodyNode(callableNode) {
+    if (!callableNode) return null;
+    for (var i = 0; i < callableNode.namedChildCount; i++) {
+      var child = callableNode.namedChild(i);
+      if (!child) continue;
+      if (child.type === 'block' || child.type === 'constructor_body') {
+        return child;
+      }
+    }
+    return callableNode;
+  }
+
+  function computeCyclomaticComplexityForBody(bodyRoot) {
+    var complexity = 1;
+
+    function visit(node, isRoot) {
+      if (!node) return;
+
+      try {
+        if (!isRoot && isCallableNode(node)) {
+          return;
+        }
+
+        if (DECISION_POINT_NODE_TYPES.indexOf(node.type) !== -1) {
+          complexity++;
+        } else if (node.type === 'switch_label') {
+          complexity++;
+        } else if (node.type === 'binary_expression') {
+          if (hasLogicalOperator(node)) {
+            complexity++;
+          }
+        }
+
+        for (var i = 0; i < node.namedChildCount; i++) {
+          visit(node.namedChild(i), false);
+        }
+      } catch (e) {
+        throw e;
+      }
+    }
+
+    visit(bodyRoot, true);
+    return complexity;
+  }
+
+  function extractCallableName(callableNode) {
+    var line = safeLine(callableNode);
+
+    var identifierNode = findFirstNamedDescendant(callableNode, function (n) {
+      return n.type === 'identifier';
+    });
+    if (identifierNode && nodeHasText(identifierNode)) {
+      return identifierNode.text;
+    }
+
+    if (callableNode.type === 'constructor_declaration' || callableNode.type === 'compact_constructor_declaration') {
+      return 'constructor' + (line ? ('@' + line) : '');
+    }
+    if (callableNode.type === 'static_initializer') {
+      return 'static_init' + (line ? ('@' + line) : '');
+    }
+    if (callableNode.type === 'instance_initializer') {
+      return 'init' + (line ? ('@' + line) : '');
+    }
+    if (callableNode.type === 'lambda_expression') {
+      return 'lambda' + (line ? ('@' + line) : '');
+    }
+
+    return callableNode.type + (line ? ('@' + line) : '');
+  }
+
+  function collectMethodComplexity(content) {
+    var tree;
+    try {
+      tree = parseTreeFromContent(content);
+    } catch (e) {
+      logger.error('Java method CC parse error: ' + e.message);
+      throw e;
+    }
+    var result = [];
+
+    function visit(node) {
+      if (!node) return;
+
+      if (isCallableNode(node)) {
+        var body = findBodyNode(node);
+        var cc = computeCyclomaticComplexityForBody(body);
+        result.push({
+          name: extractCallableName(node),
+          line: safeLine(node),
+          complexity: cc
+        });
+        for (var i = 0; i < node.namedChildCount; i++) {
+          visit(node.namedChild(i));
+        }
+        return;
+      }
+
+      for (var j = 0; j < node.namedChildCount; j++) {
+        visit(node.namedChild(j));
+      }
+    }
+
+    visit(tree.rootNode);
+    return result;
+  }
+
+  var analyse = function (filepath, content, transformFn, onError) {
+    try {
+      var cc = cyclomaticComplexity(content);
+      var methodComplexity = collectMethodComplexity(content);
+
+      var complexityReport = {
+        path: filepath,
+        totalComplexity: cc,
+        averageComplexity: cc,
+        methodComplexity: methodComplexity
+      };
+
+      if (_.isFunction(transformFn)) {
+        return transformFn(complexityReport);
+      }
+      return complexityReport;
+    } catch (e) {
+      var details = e && (e.stack || e.message || e.toString());
+      logger.error('Java analyse failed for ' + filepath + ': ' + details);
+      onError(e);
+    }
+  };
+
+  this.sourceAnalysisStream = function (filepath, transformFn) {
+    return utils.stream.reduceToObjectStream(function (content) {
+      return analyse(filepath, content, transformFn, function (e) {
+        logger.error('Error analysing content: ' + e.message);
+      });
+    });
+  };
+
+  this.fileAnalysisStream = function (filepath, transformFn) {
+    logger.info('Analysing ', filepath);
+    return utils.stream.readFileToObjectStream(filepath, function (content) {
+      return analyse(filepath, content, transformFn, function (e) {
+        logger.error('Error analysing ' + filepath + ': ' + e.message);
+      });
+    });
+  };
+};

--- a/lib/analysers/kotlin/index.js
+++ b/lib/analysers/kotlin/index.js
@@ -1,0 +1,17 @@
+/*
+ * code-forensics
+ * Copyright (C) 2016-2021 Silvio Montanari
+ * Distributed under the GNU General Public License v3.0
+ * see http://www.gnu.org/licenses/gpl.html
+ */
+
+var KotlinAnalyser = require('./kotlin_analyser'),
+    utils          = require('../../utils');
+
+var factory = new utils.SingletonFactory(KotlinAnalyser);
+
+module.exports = {
+  analyser: function() {
+    return factory.instance();
+  }
+};

--- a/lib/analysers/kotlin/kotlin_analyser.js
+++ b/lib/analysers/kotlin/kotlin_analyser.js
@@ -18,6 +18,31 @@ module.exports = function() {
   var parser = new Parser();
   parser.setLanguage(Kotlin);
 
+  // NOTE:
+  // We intentionally keep the overall (file-level) cyclomatic complexity logic
+  // and add method-level metrics in a backwards compatible way.
+
+  // --- Method-level cyclomatic complexity ---
+  // We compute CC for each "callable" block (function/method/ctor/init/getter/setter/lambda).
+  // When computing complexity for a callable body we do not descend into nested callables
+  // (otherwise outer functions would inherit inner lambda complexity).
+
+  var DECISION_POINT_NODE_TYPES = [
+    // branching
+    "if_expression",
+    "when_expression",
+    // loops
+    "for_statement",
+    "while_statement",
+    "do_while_statement",
+    // exceptions
+    "catch_block",
+    // expressions commonly treated as decision points
+    "elvis_expression",
+    "conjunction_expression", // &&
+    "disjunction_expression"  // ||
+  ];
+
   var cyclomaticComplexity = function(code) {
     var tree = parser.parse(code);
     var complexity = 1;
@@ -25,10 +50,10 @@ module.exports = function() {
     function visit(node) {
       var type = node.type;
       // Decision points for Kotlin
-      if (["if_expression", "when_expression", "for_statement", "while_statement", "do_while_statement", "catch_block", "elvis_expression", "conjunction_expression", "disjunction_expression"].includes(type)) {
+      if (DECISION_POINT_NODE_TYPES.indexOf(type) !== -1) {
         complexity++;
       }
-      
+
       for (var i = 0; i < node.namedChildCount; i++) {
         visit(node.namedChild(i));
       }
@@ -38,16 +63,165 @@ module.exports = function() {
     return complexity;
   };
 
+  // Callable nodes we want to report separately.
+  // The exact node names depend on tree-sitter-kotlin version; we keep this list permissive.
+  var CALLABLE_NODE_TYPES = [
+    "function_declaration",
+    "named_function",
+    "function_definition",
+    "secondary_constructor",
+    "constructor_declaration",
+    "init_block",
+    "getter",
+    "setter",
+    "lambda_literal",
+    "lambda_expression"
+  ];
+
+  function isCallableNode(node) {
+    return CALLABLE_NODE_TYPES.indexOf(node.type) !== -1;
+  }
+
+  function nodeHasText(node) {
+    return node && typeof node.text === 'string' && node.text.length > 0;
+  }
+
+  function findFirstNamedDescendant(node, predicate) {
+    if (!node) return null;
+    if (predicate(node)) return node;
+    for (var i = 0; i < node.namedChildCount; i++) {
+      var found = findFirstNamedDescendant(node.namedChild(i), predicate);
+      if (found) return found;
+    }
+    return null;
+  }
+
+  function findBodyNode(callableNode) {
+    if (!callableNode) return null;
+    // Prefer an explicit function body / block.
+    // For expression bodies, we just take the callable node itself as a traversal root.
+    for (var i = 0; i < callableNode.namedChildCount; i++) {
+      var child = callableNode.namedChild(i);
+      if (!child) continue;
+      if (child.type === "function_body" || child.type === "block" || child.type === "body") {
+        return child;
+      }
+    }
+    return callableNode;
+  }
+
+  function computeCyclomaticComplexityForBody(bodyRoot) {
+    var complexity = 1;
+
+    function visit(node, isRoot) {
+      if (!node) return;
+
+      // Do not include nested callables in parent method complexity.
+      if (!isRoot && isCallableNode(node)) {
+        return;
+      }
+
+      if (DECISION_POINT_NODE_TYPES.indexOf(node.type) !== -1) {
+        complexity++;
+      }
+
+      // when: some tools also count each branch; keep the old file-level behavior (+1 per when_expression)
+      // for consistency and simplicity here.
+
+      for (var i = 0; i < node.namedChildCount; i++) {
+        visit(node.namedChild(i), false);
+      }
+    }
+
+    visit(bodyRoot, true);
+    return complexity;
+  }
+
+  function safeLine(node) {
+    try {
+      // Tree-sitter: row is 0-based.
+      return (node.startPosition && typeof node.startPosition.row === 'number')
+        ? (node.startPosition.row + 1)
+        : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function extractCallableName(callableNode) {
+    // Best effort naming. If we cannot extract a stable name, fall back to type@line.
+    var line = safeLine(callableNode);
+
+    // Kotlin functions generally contain an identifier child.
+    var identifierNode = findFirstNamedDescendant(callableNode, function(n) {
+      return n.type === "simple_identifier" || n.type === "identifier";
+    });
+    if (identifierNode && nodeHasText(identifierNode)) {
+      return identifierNode.text;
+    }
+
+    // init blocks / ctors / accessors / lambdas
+    if (callableNode.type === "init_block") {
+      return "init" + (line ? ("@" + line) : "");
+    }
+    if (callableNode.type === "secondary_constructor" || callableNode.type === "constructor_declaration") {
+      return "constructor" + (line ? ("@" + line) : "");
+    }
+    if (callableNode.type === "getter") {
+      return "get" + (line ? ("@" + line) : "");
+    }
+    if (callableNode.type === "setter") {
+      return "set" + (line ? ("@" + line) : "");
+    }
+    if (callableNode.type === "lambda_literal" || callableNode.type === "lambda_expression") {
+      return "lambda" + (line ? ("@" + line) : "");
+    }
+
+    return callableNode.type + (line ? ("@" + line) : "");
+  }
+
+  function collectMethodComplexity(code) {
+    var tree = parser.parse(code);
+    var result = [];
+
+    function visit(node) {
+      if (!node) return;
+
+      if (isCallableNode(node)) {
+        var body = findBodyNode(node);
+        var cc = computeCyclomaticComplexityForBody(body);
+        result.push({
+          name: extractCallableName(node),
+          line: safeLine(node),
+          complexity: cc
+        });
+        // Still traverse nested callables so they are included in result.
+        for (var i = 0; i < node.namedChildCount; i++) {
+          visit(node.namedChild(i));
+        }
+        return;
+      }
+
+      for (var i = 0; i < node.namedChildCount; i++) {
+        visit(node.namedChild(i));
+      }
+    }
+
+    visit(tree.rootNode);
+    return result;
+  }
+
   var analyse = function(filepath, content, transformFn, onError) {
     try {
       var code = decoder.write(content);
       var cc = cyclomaticComplexity(code);
-      
+      var methodComplexity = collectMethodComplexity(code);
+
       var complexityReport = {
         path: filepath,
         totalComplexity: cc,
         averageComplexity: cc,
-        methodComplexity: [] // Not implementing method-level yet for Kotlin
+        methodComplexity: methodComplexity
       };
 
       if (_.isFunction(transformFn)) {

--- a/lib/analysers/kotlin/kotlin_analyser.js
+++ b/lib/analysers/kotlin/kotlin_analyser.js
@@ -5,16 +5,16 @@
  * see http://www.gnu.org/licenses/gpl.html
  */
 
-var _             = require('lodash'),
-    Parser        = require('tree-sitter'),
-    Kotlin        = require('tree-sitter-kotlin'),
-    StringDecoder = require('string_decoder').StringDecoder,
-    logger        = require('../../log'),
-    utils         = require('../../utils');
+var _ = require('lodash'),
+  Parser = require('tree-sitter'),
+  Kotlin = require('tree-sitter-kotlin'),
+  StringDecoder = require('string_decoder').StringDecoder,
+  logger = require('../../log'),
+  utils = require('../../utils');
 
 var decoder = new StringDecoder();
 
-module.exports = function() {
+module.exports = function () {
   var parser = new Parser();
   parser.setLanguage(Kotlin);
 
@@ -43,8 +43,17 @@ module.exports = function() {
     "disjunction_expression"  // ||
   ];
 
-  var cyclomaticComplexity = function(code) {
-    var tree = parser.parse(code);
+  function parseTreeFromCode(code) {
+    var input = (typeof code === 'string') ? code : decoder.write(code);
+    var chunkSize = 4096;
+    return parser.parse(function(index) {
+      if (index >= input.length) return null;
+      return input.slice(index, index + chunkSize);
+    });
+  }
+
+  var cyclomaticComplexity = function (code) {
+    var tree = parseTreeFromCode(code);
     var complexity = 1;
 
     function visit(node) {
@@ -153,7 +162,7 @@ module.exports = function() {
     var line = safeLine(callableNode);
 
     // Kotlin functions generally contain an identifier child.
-    var identifierNode = findFirstNamedDescendant(callableNode, function(n) {
+    var identifierNode = findFirstNamedDescendant(callableNode, function (n) {
       return n.type === "simple_identifier" || n.type === "identifier";
     });
     if (identifierNode && nodeHasText(identifierNode)) {
@@ -181,7 +190,7 @@ module.exports = function() {
   }
 
   function collectMethodComplexity(code) {
-    var tree = parser.parse(code);
+    var tree = parseTreeFromCode(code);
     var result = [];
 
     function visit(node) {
@@ -211,7 +220,7 @@ module.exports = function() {
     return result;
   }
 
-  var analyse = function(filepath, content, transformFn, onError) {
+  var analyse = function (filepath, content, transformFn, onError) {
     try {
       var code = decoder.write(content);
       var cc = cyclomaticComplexity(code);
@@ -228,23 +237,23 @@ module.exports = function() {
         return transformFn(complexityReport);
       }
       return complexityReport;
-    } catch(e) {
+    } catch (e) {
       onError(e);
     }
   };
 
-  this.sourceAnalysisStream = function(filepath, transformFn) {
-    return utils.stream.reduceToObjectStream(function(content) {
-      return analyse(filepath, content, transformFn, function(e) {
+  this.sourceAnalysisStream = function (filepath, transformFn) {
+    return utils.stream.reduceToObjectStream(function (content) {
+      return analyse(filepath, content, transformFn, function (e) {
         logger.error('Error analysing content: ' + e.message);
       });
     });
   };
 
-  this.fileAnalysisStream = function(filepath, transformFn) {
+  this.fileAnalysisStream = function (filepath, transformFn) {
     logger.info('Analysing ', filepath);
-    return utils.stream.readFileToObjectStream(filepath, function(content) {
-      return analyse(filepath, content, transformFn, function(e) {
+    return utils.stream.readFileToObjectStream(filepath, function (content) {
+      return analyse(filepath, content, transformFn, function (e) {
         logger.error('Error analysing ' + filepath + ': ' + e.message);
       });
     });

--- a/lib/analysers/kotlin/kotlin_analyser.js
+++ b/lib/analysers/kotlin/kotlin_analyser.js
@@ -1,0 +1,78 @@
+/*
+ * code-forensics
+ * Copyright (C) 2016-2021 Silvio Montanari
+ * Distributed under the GNU General Public License v3.0
+ * see http://www.gnu.org/licenses/gpl.html
+ */
+
+var _             = require('lodash'),
+    Parser        = require('tree-sitter'),
+    Kotlin        = require('tree-sitter-kotlin'),
+    StringDecoder = require('string_decoder').StringDecoder,
+    logger        = require('../../log'),
+    utils         = require('../../utils');
+
+var decoder = new StringDecoder();
+
+module.exports = function() {
+  var parser = new Parser();
+  parser.setLanguage(Kotlin);
+
+  var cyclomaticComplexity = function(code) {
+    var tree = parser.parse(code);
+    var complexity = 1;
+
+    function visit(node) {
+      var type = node.type;
+      // Decision points for Kotlin
+      if (["if_expression", "when_expression", "for_statement", "while_statement", "do_while_statement", "catch_block", "elvis_expression", "conjunction_expression", "disjunction_expression"].includes(type)) {
+        complexity++;
+      }
+      
+      for (var i = 0; i < node.namedChildCount; i++) {
+        visit(node.namedChild(i));
+      }
+    }
+
+    visit(tree.rootNode);
+    return complexity;
+  };
+
+  var analyse = function(filepath, content, transformFn, onError) {
+    try {
+      var code = decoder.write(content);
+      var cc = cyclomaticComplexity(code);
+      
+      var complexityReport = {
+        path: filepath,
+        totalComplexity: cc,
+        averageComplexity: cc,
+        methodComplexity: [] // Not implementing method-level yet for Kotlin
+      };
+
+      if (_.isFunction(transformFn)) {
+        return transformFn(complexityReport);
+      }
+      return complexityReport;
+    } catch(e) {
+      onError(e);
+    }
+  };
+
+  this.sourceAnalysisStream = function(filepath, transformFn) {
+    return utils.stream.reduceToObjectStream(function(content) {
+      return analyse(filepath, content, transformFn, function(e) {
+        logger.error('Error analysing content: ' + e.message);
+      });
+    });
+  };
+
+  this.fileAnalysisStream = function(filepath, transformFn) {
+    logger.info('Analysing ', filepath);
+    return utils.stream.readFileToObjectStream(filepath, function(content) {
+      return analyse(filepath, content, transformFn, function(e) {
+        logger.error('Error analysing ' + filepath + ': ' + e.message);
+      });
+    });
+  };
+};

--- a/lib/models/language_definitions.js
+++ b/lib/models/language_definitions.js
@@ -12,6 +12,7 @@ var DefinitionsArchive = require('../utils').DefinitionsArchive;
 module.exports = _.tap(new DefinitionsArchive(), function(archive) {
   _.each({
     ruby:       ['rb'],
-    javascript: ['js']
+    javascript: ['js'],
+    kotlin:     ['kt', 'kts']
   }, function(extensions, lang) { archive.addDefinition(lang, extensions); });
 });

--- a/lib/models/language_definitions.js
+++ b/lib/models/language_definitions.js
@@ -13,6 +13,7 @@ module.exports = _.tap(new DefinitionsArchive(), function(archive) {
   _.each({
     ruby:       ['rb'],
     javascript: ['js'],
-    kotlin:     ['kt', 'kts']
+    kotlin:     ['kt', 'kts'],
+    java:       ['java']
   }, function(extensions, lang) { archive.addDefinition(lang, extensions); });
 });

--- a/lib/tasks/complexity_analysis/java_tasks.js
+++ b/lib/tasks/complexity_analysis/java_tasks.js
@@ -1,0 +1,45 @@
+/*
+ * code-forensics
+ * Copyright (C) 2016-2021 Silvio Montanari
+ * Distributed under the GNU General Public License v3.0
+ * see http://www.gnu.org/licenses/gpl.html
+ */
+
+var _    = require('lodash'),
+    java = require('../../analysers/java'),
+    pp   = require('../../parallel_processing'),
+    utils = require('../../utils');
+
+module.exports = function(taskDef, context, helpers) {
+  var javaComplexityReport = function() {
+    var stream = pp.streamProcessor().mergeAll(context.repository.sourceFiles('java'), function(file) {
+      return java.analyser().fileAnalysisStream(file.absolutePath, function(report) {
+        return _.extend(report, { path: file.relativePath });
+      });
+    });
+
+    return utils.json.objectArrayToFileStream(helpers.files.codeComplexity('java'), stream);
+  };
+
+  return {
+    functions: {
+      javaComplexityReport: javaComplexityReport
+    },
+    tasks: function() {
+      taskDef.addTask('java-complexity-report', javaComplexityReport);
+      taskDef.addAnalysisTask('java-complexity-trend-analysis',
+        {
+          description: 'Analyse the complexity trend in time for a particular Java file',
+          reportName: 'complexity-trend',
+          parameters: [{ name: 'targetFile', required: true }, { name: 'dateFrom' }, { name: 'dateTo' }],
+          reportFile: 'complexity-trend-data.json',
+          run: function(publisher) {
+            _.each(['total', 'func-mean', 'func-sd'], function(name) { publisher.enableDiagram(name); });
+            var stream = helpers.revision.revisionAnalysisStream(java.analyser());
+            return utils.json.objectArrayToFileStream(publisher.addReportFile(), stream);
+          }
+        }
+      );
+    }
+  };
+};

--- a/lib/tasks/complexity_analysis/kotlin_tasks.js
+++ b/lib/tasks/complexity_analysis/kotlin_tasks.js
@@ -1,0 +1,45 @@
+/*
+ * code-forensics
+ * Copyright (C) 2016-2021 Silvio Montanari
+ * Distributed under the GNU General Public License v3.0
+ * see http://www.gnu.org/licenses/gpl.html
+ */
+
+var _      = require('lodash'),
+    kotlin = require('../../analysers/kotlin'),
+    pp     = require('../../parallel_processing'),
+    utils  = require('../../utils');
+
+module.exports = function(taskDef, context, helpers) {
+  var kotlinComplexityReport = function() {
+    var stream = pp.streamProcessor().mergeAll(context.repository.sourceFiles('kotlin'), function(file) {
+      return kotlin.analyser().fileAnalysisStream(file.absolutePath, function(report) {
+        return _.extend(report, { path: file.relativePath });
+      });
+    });
+
+    return utils.json.objectArrayToFileStream(helpers.files.codeComplexity('kotlin'), stream);
+  };
+
+  return {
+    functions: {
+      kotlinComplexityReport: kotlinComplexityReport
+    },
+    tasks: function() {
+      taskDef.addTask('kotlin-complexity-report', kotlinComplexityReport);
+      taskDef.addAnalysisTask('kotlin-complexity-trend-analysis',
+        {
+          description: 'Analyse the complexity trend in time for a particular Kotlin file',
+          reportName: 'complexity-trend',
+          parameters: [{ name: 'targetFile', required: true }, { name: 'dateFrom' }, { name: 'dateTo' }],
+          reportFile: 'complexity-trend-data.json',
+          run: function(publisher) {
+            _.each(['total', 'func-mean', 'func-sd'], function(name) { publisher.enableDiagram(name); });
+            var stream = helpers.revision.revisionAnalysisStream(kotlin.analyser());
+            return utils.json.objectArrayToFileStream(publisher.addReportFile(), stream);
+          }
+        }
+      );
+    }
+  };
+};


### PR DESCRIPTION
Adds Kotlin and Java support for complexity analysis.

This was mostly vibe-coded, but the results appear reasonable.

Cyclomatic complexity is computed using a McCabe-style approach inspired by Detekt’s CyclomaticComplexMethod rule, with parsing handled by tree-sitter-kotlin/tree-sitter-java.

Feedback is welcome.